### PR TITLE
Add getCurrentEpochTime accuracy test

### DIFF
--- a/plow-extras-time/changelog.md
+++ b/plow-extras-time/changelog.md
@@ -1,6 +1,9 @@
 # plow-extras-time
 ## changelog
 
+* 0.3.0.1 (24. August 2018)
+added getCurrentEpochTime accuracy test
+
 * 0.3.0.0
 upgrade to ghc 8.2.2
 

--- a/plow-extras-time/plow-extras-time.cabal
+++ b/plow-extras-time/plow-extras-time.cabal
@@ -1,5 +1,5 @@
 Name:                   plow-extras-time
-Version:                0.3.0.0
+Version:                0.3.0.1
 Author:                 Lingpo Huang <lingpo.huang@plowtech.net>, Darren Midkiff <darren.midkiff@plowtech.net>
 Maintainer:             Lingpo Huang <lingpo.huang@plowtech.net>, Darren Midkiff <darren.midkiff@plowtech.net>
 License:                BSD3
@@ -37,6 +37,8 @@ test-suite plow-extras-time-test
                , tasty-hunit
                , quickcheck-instances
                , time
+               , QuickCheck
+               , process
 
 Source-Repository head
   Type:                 git

--- a/plow-extras-time/test/Main.hs
+++ b/plow-extras-time/test/Main.hs
@@ -3,11 +3,13 @@ import           Data.Time.Calendar           (Day)
 import           Data.Time.Clock              (diffUTCTime)
 import           Plow.Extras.Crontab
 import           Plow.Extras.Time
+import           Test.QuickCheck.Property     (ioProperty)
 import           Test.QuickCheck.Instances    ()
 import           Test.Tasty                   (TestTree, defaultMain, testGroup)
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck        (testProperty)
 import           Text.ParserCombinators.ReadP
+import           System.Process               (readProcess)
 
 main :: IO ()
 main = defaultMain tests
@@ -20,6 +22,10 @@ timeTests = testGroup "plow-extras-time"
       \t -> round (diffUTCTime (intToUTCTime $ utcTimeToInt t) t) == (0 :: Int)
   , testProperty "utcTimeToInt . intToUTCTime = id" $
       \t -> (utcTimeToInt . intToUTCTime) t == t
+  , testProperty "Time accuracy of getCurrentEpochTime" $ ioProperty $ do
+      tstr <- init <$> readProcess "date" ["+%s"] []
+      t <- getCurrentEpochTime
+      pure $ abs (t - read tstr) <= 1
   ]
 
 cronParseTests = testGroup "Crontab Parser"


### PR DESCRIPTION
A test that check against the `date` command, whether `getCurrentEpochTime` gives the correct answer.